### PR TITLE
Allow specification by date rather than year

### DIFF
--- a/examples/microclimate/era5_point.jl
+++ b/examples/microclimate/era5_point.jl
@@ -16,7 +16,7 @@ using Dates
 using GeoInterface: Wrappers as GIW
 
 point = GIW.Point((-89.4557, 43.1379))
-years = 2000:2000
+dates = Date(2000, 1, 1):Day(1):Date(2000, 12, 31)
 
 # ---------------------------------------------------------------------------
 # Build the model
@@ -38,7 +38,7 @@ model = MicroMapModel(;
 # Rasters Zarr backend for the ARCO-ERA5 store. Once the JSON version
 # conflict between RasterDataSources/dev and ZarrDatasets is resolved this
 # can become a direct dependency.
-problem = MicroVectorProblem(; model, points = [point], years,
+problem = MicroVectorProblem(; model, points = [point], dates,
     soil_profile = example_soil_profile(inner.depths),
 )
 output = solve(problem)

--- a/src/climate/weather.jl
+++ b/src/climate/weather.jl
@@ -118,6 +118,97 @@ The time step a source's `_load_weather` produces. Default
 @inline _days_of_year(::DailyResolution, nyears) = repeat(1:365, nyears)
 @inline _days_of_year(::HourlyResolution, nyears) = repeat(1:365, nyears)
 
+# ---------------------------------------------------------------------------
+# Date-range helpers
+# ---------------------------------------------------------------------------
+
+# Convert an old-style integer years range to a full-calendar Date range.
+_years_to_dates(years::AbstractRange{Int}) =
+    Date(first(years), 1, 1):Day(1):Date(last(years), 12, 31)
+
+# Derive the integer year span that must be loaded from weather sources to
+# cover all dates.
+_years_from_dates(d::Date)                 = year(d):year(d)
+_years_from_dates(r::AbstractRange{Date})  = minimum(year, r):maximum(year, r)
+
+# Day-of-year on the 365-day calendar (Feb 29 is dropped, so March 1 = doy 60
+# whether or not the year is a leap year).
+function _doy_noleap(d::Date)
+    doy = dayofyear(d)
+    isleapyear(year(d)) && d >= Date(year(d), 3, 1) && (doy -= 1)
+    return doy
+end
+
+_is_leapday(d::Date) = isleapyear(year(d)) && month(d) == 2 && day(d) == 29
+
+# Normalise user-supplied dates to a sorted Vector{Date}, dropping Feb 29
+# (consistent with the 365-day-per-year convention throughout).
+_normalise_dates(d::Date) = _is_leapday(d) ? Date[] : [d]
+function _normalise_dates(r::AbstractRange{Date})
+    v = filter(!_is_leapday, collect(r))
+    isempty(v) && error(
+        "No valid simulation dates remain after dropping Feb 29 " *
+        "(leap days are not yet supported).")
+    return v
+end
+
+# Compute the 1-based positional Ti range into the full-years weather stack,
+# and the day-of-year vector for the solver (one entry per unique day, or per
+# month for monthly sources). `dates_vec` must already be normalised (sorted,
+# no Feb 29).
+function _ti_range_for_dates(::MonthlyResolution, years, dates_vec::Vector{Date})
+    start_d, end_d = minimum(dates_vec), maximum(dates_vec)
+    years_v = collect(years)
+    yi_start = findfirst(==(year(start_d)), years_v)
+    yi_end   = findfirst(==(year(end_d)),   years_v)
+    ti_start = (yi_start - 1) * 12 + month(start_d)
+    ti_end   = (yi_end   - 1) * 12 + month(end_d)
+    days_doy = Int[]
+    d = Date(year(start_d), month(start_d), 1)
+    stop = Date(year(end_d), month(end_d), 1)
+    while d <= stop
+        push!(days_doy, Microclimate.DEFAULT_DAYS[month(d)])
+        d += Month(1)
+    end
+    return ti_start, ti_end, days_doy
+end
+
+function _ti_range_for_dates(::DailyResolution, years, dates_vec::Vector{Date})
+    start_d, end_d = minimum(dates_vec), maximum(dates_vec)
+    years_v = collect(years)
+    yi_start = findfirst(==(year(start_d)), years_v)
+    yi_end   = findfirst(==(year(end_d)),   years_v)
+    ti_start = (yi_start - 1) * 365 + _doy_noleap(start_d)
+    ti_end   = (yi_end   - 1) * 365 + _doy_noleap(end_d)
+    return ti_start, ti_end, _doy_noleap.(dates_vec)
+end
+
+function _ti_range_for_dates(::HourlyResolution, years, dates_vec::Vector{Date})
+    start_d, end_d = minimum(dates_vec), maximum(dates_vec)
+    years_v = collect(years)
+    yi_start = findfirst(==(year(start_d)), years_v)
+    yi_end   = findfirst(==(year(end_d)),   years_v)
+    ti_start = (yi_start - 1) * 8760 + (_doy_noleap(start_d) - 1) * 24 + 1
+    ti_end   = (yi_end   - 1) * 8760 + _doy_noleap(end_d) * 24
+    return ti_start, ti_end, _doy_noleap.(dates_vec)
+end
+
+# One "anchor" Date per solver step — used to carry the year when building
+# the output DateTime axis. Monthly: 1st of each selected month. Daily/hourly:
+# the dates_vec itself (already one per calendar day).
+function _step_anchor_dates(::MonthlyResolution, dates_vec::Vector{Date})
+    seen = Set{Tuple{Int,Int}}()
+    result = Date[]
+    for d in sort(dates_vec)
+        k = (year(d), month(d))
+        k in seen && continue
+        push!(seen, k)
+        push!(result, Date(year(d), month(d), 1))
+    end
+    return result
+end
+_step_anchor_dates(::TemporalResolution, dates_vec::Vector{Date}) = dates_vec
+
 # Monthly forcing → independent representative days (Fortran "monthly mode");
 # daily/hourly forcing → continuous run with state carrying day-to-day.
 @inline _time_mode(::MonthlyResolution) = Microclimate.NonConsecutiveDayMode()
@@ -492,14 +583,14 @@ and the env-minmax struct type is `MonthlyMinMaxEnvironment` or
 else — `DailyTimeseries`, `HourlyTimeseries`, the intermediate buffers —
 just scales with the total timestep count.
 """
-function allocate_weather_buffers(source::Type{<:RasterDataSources.RasterDataSource}, nyears::Int)
-    _allocate_weather_buffers(temporal_resolution(source), source, nyears)
+function allocate_weather_buffers(source::Type{<:RasterDataSources.RasterDataSource},
+                                  days_of_year::AbstractVector{Int})
+    _allocate_weather_buffers(temporal_resolution(source), source, days_of_year)
 end
 
 function _allocate_weather_buffers(resolution::Union{MonthlyResolution, DailyResolution},
-                                   source, nyears::Int)
-    nsteps = nyears * steps_per_year(resolution)
-    days_of_year = _days_of_year(resolution, nyears)
+                                   ::Any, days_of_year::AbstractVector{Int})
+    nsteps = length(days_of_year)
     zeros_float(n) = zeros(Float64, n)
 
     # Canonical buffers — each carries the unit appropriate for its quantity.
@@ -577,9 +668,9 @@ end
 # Hourly mode: env_minmax = nothing, env_hourly arrays ARE the canonical
 # buffers (shared storage), env_daily arrays sit at 1/24 the resolution
 # and are filled by aggregating the hourly canonical buffers.
-function _allocate_weather_buffers(::HourlyResolution, source, nyears::Int)
-    nhours = nyears * 8760  # 24 × 365 (Feb 29 dropped)
-    ndays = nyears * 365
+function _allocate_weather_buffers(::HourlyResolution, ::Any, days_of_year::AbstractVector{Int})
+    ndays  = length(days_of_year)    # one per unique day (Feb 29 dropped)
+    nhours = ndays * 24
     zeros_float(n) = zeros(Float64, n)
 
     # Hourly canonical buffers — shared with `environment_hourly`.
@@ -599,11 +690,9 @@ function _allocate_weather_buffers(::HourlyResolution, source, nyears::Int)
     dewpoint_temperature = zeros(typeof(0.0u"K"), nhours)
     actual_vapour_pressure = zeros(typeof(0.0u"kPa"), nhours)
 
-    # `environment_daily` lives at 365/year — aggregated from hourly.
+    # `environment_daily` lives at one entry per unique day — aggregated from hourly.
     rainfall_daily = zeros(typeof(0.0u"kg/m^2"), ndays)
     deep_soil_temperature = zeros(typeof(0.0u"K"), ndays)
-
-    days_of_year = repeat(1:365, nyears)
 
     environment_daily = DailyTimeseries(;
         shade = zeros_float(ndays),
@@ -977,7 +1066,15 @@ end
 # Annual mean of hourly reference_temperature, broadcast across all 365
 # daily entries of `deep_soil_temperature`.
 function derive!(::Val{:deep_soil_temperature_from_hourly}, buffers, ctx)
-    nyears = length(buffers.deep_soil_temperature) ÷ 365
+    ndays  = length(buffers.deep_soil_temperature)
+    nhours = length(buffers.reference_temperature)
+    if ndays < 365
+        # Sub-annual run: fill with mean of all available hours.
+        run_mean = sum(buffers.reference_temperature) / nhours
+        fill!(buffers.deep_soil_temperature, run_mean)
+        return nothing
+    end
+    nyears = ndays ÷ 365
     @inbounds for y in 1:nyears
         h0 = (y - 1) * 8760
         annual_sum = zero(eltype(buffers.reference_temperature))
@@ -1045,6 +1142,12 @@ function _annual_means!(out::AbstractVector,
                         values::AbstractVector,
                         nyears::Int,
                         steps_per_year::Int)
+    if nyears == 0
+        # Sub-annual run: fill with mean of all available steps.
+        run_mean = sum(values) / length(values)
+        fill!(out, run_mean)
+        return out
+    end
     @inbounds for y in 1:nyears
         annual_sum = zero(eltype(values))
         for k in 1:steps_per_year

--- a/src/common.jl
+++ b/src/common.jl
@@ -316,22 +316,22 @@ end
 function _build_inputs_and_pool(;
     model, weather_source, weather, terrain,
     albedo_grid, roughness_grid, canonical_overrides,
-    init_inputs, soil_moisture_available, years, cloud_constants,
+    init_inputs, soil_moisture_available, days, cloud_constants,
     soil_profile,
 )
     (; micro_model, lapse_rate_model) = model
     vapour_pressure_method = micro_model.vapour_pressure_equation
 
     resolution = temporal_resolution(weather_source)
-    ndays = steps_per_year(resolution) * length(years)
-    days = _days_of_year(resolution, length(years))
     time_mode = _time_mode(resolution)
-    nsteps = length(cloud_constants.hours) * ndays
     nmax = cloud_constants.solar_model.wavelength_count
+    # `days` is the doy vector: one per unique day (daily/hourly) or one per
+    # selected month (monthly). Solar radiation is computed for each entry × 24 hours.
+    nsteps = length(cloud_constants.hours) * length(days)
     allocate_scratch() = (;
-        weather = allocate_weather_buffers(weather_source, length(years)),
+        weather = allocate_weather_buffers(weather_source, days),
         solar = (;
-            out = allocate_output_arrays(nsteps, ndays, nmax),
+            out = allocate_output_arrays(nsteps, length(days), nmax),
             buffers = allocate_buffers(nmax, cloud_constants.solar_model.diffuse_model),
         ),
         cloud_constants,
@@ -411,8 +411,9 @@ function CommonSolve.solve!(cache::MicroMapCache)
     proto, first_I, first_result = _solve_proto_pixel!(cache)
     try
         layers = cache.problem.model.output_layers
-        output = _allocate_output(cache.problem.model.micro_model, proto.micro.problem.days,
-            cache.terrain, first_result, layers, first(cache.problem.years), cache.mask)
+        output = _allocate_output(cache.problem.model.micro_model,
+            cache.terrain, first_result, layers,
+            cache.init_inputs.anchor_dates, cache.mask)
         _write_output!(output, first_result, layers, first_I)
         return _solve_remaining!(output, cache, proto, first_I)
     catch
@@ -484,9 +485,10 @@ end
 # Output stack allocation and per-pixel writes
 # ---------------------------------------------------------------------------
 
-function _allocate_output(model::MicroModel, days, terrain, proto, layers::Tuple, year::Integer, mask)
+function _allocate_output(model::MicroModel, terrain, proto, layers::Tuple,
+                          anchor_dates::AbstractVector{Date}, mask)
     spatial_dims = dims(terrain.elevation)
-    ti = Ti(_ti_datetime_axis(year, days, model.hours))
+    ti = Ti(_ti_datetime_axis(anchor_dates, model.hours))
     # Dim lookups must be plain numbers, not Unitful — Unitful in dims
     # breaks NetCDF I/O and surprises selectors. Strip both to metres so
     # `depth` and `height` share a single linear axis.
@@ -500,17 +502,16 @@ function _allocate_output(model::MicroModel, days, terrain, proto, layers::Tuple
     end))
 end
 
-# Build the Ti axis as actual DateTimes. `days` are day-of-year integers
-# (mid-month for monthly mode; 1:365 for daily); `hours` are 0..23
-# floats; the result is one DateTime per (day, hour) row of the inner
-# Microclimate output.
-function _ti_datetime_axis(year::Integer, days::AbstractVector{<:Integer},
-                           hours::AbstractVector)
-    out = Vector{DateTime}(undef, length(days) * length(hours))
-    base = DateTime(year, 1, 1)
+# Build the Ti axis as actual DateTimes. `anchor_dates` has one entry per
+# solver step (one per unique day for daily/hourly; one per selected month
+# for monthly). `hours` are 0..23 floats. The result is one DateTime per
+# (step, hour) pair. Using actual calendar dates (not doy arithmetic) keeps
+# cross-year and leap-year boundaries correct.
+function _ti_datetime_axis(anchor_dates::AbstractVector{Date}, hours::AbstractVector)
+    out = Vector{DateTime}(undef, length(anchor_dates) * length(hours))
     k = 1
-    for d in days, h in hours
-        out[k] = base + Day(d - 1) + Hour(round(Int, h))
+    for d in anchor_dates, h in hours
+        out[k] = DateTime(d) + Hour(round(Int, h))
         k += 1
     end
     return out

--- a/src/raster.jl
+++ b/src/raster.jl
@@ -16,10 +16,10 @@
 #     run template at `init` time
 
 """
-    MicroRasterProblem(; model, area, years, template, soil_profile, init=nothing, data=(;))
+    MicroRasterProblem(; model, area, dates, template, soil_profile, init=nothing, data=(;))
 
 Concrete grid-microclimate run: pairs a `MicroMapModel` with a spatial
-extent, time range, soil column profile, initial conditions, and any
+extent, date range, soil column profile, initial conditions, and any
 per-run data overrides.
 
 - `model::MicroMapModel`
@@ -27,7 +27,11 @@ per-run data overrides.
   GeoInterface-conformant geometry (rasterised into a Bool mask via
   `Rasters.boolmask`; pixels outside the geometry are skipped and left
   as `missing` in the output)
-- `years::AbstractRange`
+- `dates` — any contiguous date range:
+    * `Date(2000, 6, 29)` — single day
+    * `Date(2000, 6, 1):Day(1):Date(2000, 6, 30)` — one month
+    * `Date(2000, 1, 1):Day(1):Date(2000, 12, 31)` — full year
+  Feb 29 is dropped (365-day calendar). Cross-year ranges are supported.
 - `template` — spatial grid the run executes on. Required; no fallback.
     * `Type{<:RasterDataSource}` (e.g. `SRTM`) — load that dataset over
       `area` and use it as the grid; weather is resampled onto it.
@@ -46,17 +50,17 @@ per-run data overrides.
       `mean_temperature`, `cloud_cover`). Each as a `Raster` in canonical
       units; resampled to the run template automatically.
 """
-@kwdef struct MicroRasterProblem{M<:MicroMapModel,A,Y,T,SP<:SoilProfile,IT,D<:NamedTuple}
+@kwdef struct MicroRasterProblem{M<:MicroMapModel,A,DT<:Union{Date,AbstractRange{Date}},T,SP<:SoilProfile,IT,D<:NamedTuple}
     model::M
     area::A
-    years::Y
+    dates::DT
     template::T
     soil_profile::SP
     init::IT = nothing
     data::D = (;)
 end
 
-# Positional-`model` convenience: `MicroRasterProblem(model; area, years, ...)`.
+# Positional-`model` convenience: `MicroRasterProblem(model; area, dates, ...)`.
 MicroRasterProblem(model::MicroMapModel; kwargs...) =
     MicroRasterProblem(; model, kwargs...)
 
@@ -186,12 +190,19 @@ overrides), pre-resolve every grid onto the run template, allocate the
 worker-cache pool, and prepare for `solve!`.
 """
 function CommonSolve.init(problem::MicroRasterProblem)
-    (; model, area, years, soil_profile, data) = problem
+    (; model, area, dates, soil_profile, data) = problem
     (; dem_source, weather_source, landcover_source,
        surface_albedo_source, roughness_height_source) = model
 
     init_inputs = _resolve_init(problem.init, model.micro_model)
     soil_moisture_available = _has_canonical_input(:soil_moisture, weather_source, data)
+
+    # Normalise the user-supplied dates: drop Feb 29, get a sorted Vector{Date}.
+    dates_vec = _normalise_dates(dates)
+    years = _years_from_dates(dates)
+    resolution = temporal_resolution(weather_source)
+    ti_start, ti_end, days_doy = _ti_range_for_dates(resolution, years, dates_vec)
+    anchor_dates = _step_anchor_dates(resolution, dates_vec)
 
     # Resolve the spatial template (Raster or RDS source loaded over
     # `area`), then resample the native-resolution weather onto it so
@@ -207,10 +218,15 @@ function CommonSolve.init(problem::MicroRasterProblem)
     extent = _to_extent(area)
     buffer_deg = weather_area_buffer(weather_source)
     weather_area = Extents.buffer(extent, (X = buffer_deg, Y = buffer_deg))
-    weather = _resolve_weather(data, weather_source, weather_area, years)
+    weather_full = _resolve_weather(data, weather_source, weather_area, years)
     dem_native = _resolve_dem(data, dem_source, extent)
     template_2d = _resolve_template(problem.template, extent)
-    weather = _resample_weather_to_template(weather, template_2d)
+    weather_full = _resample_weather_to_template(weather_full, template_2d)
+    # Slice the loaded (full-year) weather stack to the requested date range.
+    # Positional integer Ti indexing works for both integer Ti (most sources)
+    # and DateTime Ti (ERA5 Zarr). `stack[Ti(...)]` applies the slice to all
+    # layers simultaneously — unlike `map(f, stack)` which is pixel-wise.
+    weather = weather_full[Ti(ti_start:ti_end)]
     template = first(values(weather))
     terrain = compute_terrain_grids(dem_native;
         template = template_2d, n_horizon_angles = N_HORIZON_ANGLES)
@@ -230,14 +246,14 @@ function CommonSolve.init(problem::MicroRasterProblem)
     build_inputs, cache_pool = _build_inputs_and_pool(;
         model, weather_source, weather, terrain,
         albedo_grid, roughness_grid, canonical_overrides,
-        init_inputs, soil_moisture_available, years, cloud_constants,
+        init_inputs, soil_moisture_available, days = days_doy, cloud_constants,
         soil_profile,
     )
 
     return MicroMapCache(
         problem, weather, terrain, albedo_grid, roughness_grid,
         canonical_overrides, mask, cache_pool,
-        (; init_inputs, build_inputs),
+        (; init_inputs, build_inputs, anchor_dates),
         cloud_constants,
     )
 end
@@ -256,7 +272,7 @@ CommonSolve.solve(problem::MicroRasterProblem) = solve!(init(problem))
 function Base.show(io::IO, ::MIME"text/plain", problem::MicroRasterProblem)
     println(io, "MicroRasterProblem")
     println(io, "  area:     ", problem.area)
-    println(io, "  years:    ", problem.years)
+    println(io, "  dates:    ", problem.dates)
     println(io, "  template: ", _template_label(problem.template))
     println(io)
     println(io, "forcings:")

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -23,17 +23,21 @@ const GI = GeoInterface
 const _POINTS_LOAD_BUFFER = 2.0
 
 """
-    MicroVectorProblem(; model, points, years, soil_profile, init=nothing, data=(;))
+    MicroVectorProblem(; model, points, dates, soil_profile, init=nothing, data=(;))
 
 Concrete points-mode microclimate run: pairs a `MicroMapModel` with a list
-of GeoInterface-conformant points, a time range, soil column profile,
+of GeoInterface-conformant points, a date range, soil column profile,
 initial conditions, and any per-run data overrides.
 
 - `model::MicroMapModel`
 - `points::AbstractVector` — any iterable of GeoInterface point-like objects
   (e.g. `Vector{Tuple{Float64,Float64}}` of `(longitude, latitude)`).
   The bounding extent is derived via `GeoInterface.extent(MultiPoint(points))`.
-- `years::AbstractRange`
+- `dates` — any contiguous date range:
+    * `Date(2000, 6, 29)` — single day
+    * `Date(2000, 6, 1):Day(1):Date(2000, 6, 30)` — one month
+    * `Date(2000, 1, 1):Day(1):Date(2000, 12, 31)` — full year
+  Feb 29 is dropped (365-day calendar). Cross-year ranges are supported.
 - `soil_profile::SoilProfile` — per-depth `bulk_density` and
   `mineral_density`. Currently uniform across points (a per-point
   `soil_profile_source` is a planned extension).
@@ -47,16 +51,16 @@ where the `:point` dim carries a `MergedLookup` of `(x, y)` tuples so
 callers can recover coordinates via `lookup`/`val` or by indexing with
 `X(At(x)), Y(At(y))` selectors.
 """
-@kwdef struct MicroVectorProblem{M<:MicroMapModel,PT<:AbstractVector,Y,SP<:SoilProfile,IT,D<:NamedTuple}
+@kwdef struct MicroVectorProblem{M<:MicroMapModel,PT<:AbstractVector,DT<:Union{Date,AbstractRange{Date}},SP<:SoilProfile,IT,D<:NamedTuple}
     model::M
     points::PT
-    years::Y
+    dates::DT
     soil_profile::SP
     init::IT = nothing
     data::D = (;)
 end
 
-# Positional-`model` convenience: `MicroVectorProblem(model; points, years, ...)`.
+# Positional-`model` convenience: `MicroVectorProblem(model; points, dates, ...)`.
 MicroVectorProblem(model::MicroMapModel; kwargs...) =
     MicroVectorProblem(; model, kwargs...)
 
@@ -161,12 +165,18 @@ extract every forcing into `Dim{:point}`-keyed Rasters, allocate the
 worker-cache pool, and prepare for `solve!`. No resampling is performed.
 """
 function CommonSolve.init(problem::MicroVectorProblem)
-    (; model, points, years, soil_profile, data) = problem
+    (; model, points, dates, soil_profile, data) = problem
     (; dem_source, weather_source, landcover_source,
        surface_albedo_source, roughness_height_source) = model
 
     init_inputs = _resolve_init(problem.init, model.micro_model)
     soil_moisture_available = _has_canonical_input(:soil_moisture, weather_source, data)
+
+    dates_vec = _normalise_dates(dates)
+    years = _years_from_dates(dates)
+    resolution = temporal_resolution(weather_source)
+    ti_start, ti_end, days_doy = _ti_range_for_dates(resolution, years, dates_vec)
+    anchor_dates = _step_anchor_dates(resolution, dates_vec)
 
     area = _points_extent(points)
     points_dim = _make_points_dim(points)
@@ -183,6 +193,9 @@ function CommonSolve.init(problem::MicroVectorProblem)
     weather_area = Extents.buffer(area,
         (X = _POINTS_LOAD_BUFFER, Y = _POINTS_LOAD_BUFFER))
     weather_native = _resolve_weather(data, weather_source, weather_area, years)
+    # Slice to the requested date range before per-point extraction —
+    # positional Ti indexing works for both integer and DateTime Ti axes.
+    weather_native = weather_native[Ti(ti_start:ti_end)]
     dem_native = _resolve_dem(data, dem_source, area)
     terrain_native = compute_terrain_grids(dem_native;
         template = nothing, n_horizon_angles = N_HORIZON_ANGLES)
@@ -203,14 +216,14 @@ function CommonSolve.init(problem::MicroVectorProblem)
     build_inputs, cache_pool = _build_inputs_and_pool(;
         model, weather_source, weather, terrain,
         albedo_grid, roughness_grid, canonical_overrides,
-        init_inputs, soil_moisture_available, years, cloud_constants,
+        init_inputs, soil_moisture_available, days = days_doy, cloud_constants,
         soil_profile,
     )
 
     return MicroMapCache(
         problem, weather, terrain, albedo_grid, roughness_grid,
         canonical_overrides, nothing, cache_pool,
-        (; init_inputs, build_inputs),
+        (; init_inputs, build_inputs, anchor_dates),
         cloud_constants,
     )
 end
@@ -229,7 +242,7 @@ CommonSolve.solve(problem::MicroVectorProblem) = solve!(init(problem))
 function Base.show(io::IO, ::MIME"text/plain", problem::MicroVectorProblem)
     println(io, "MicroVectorProblem")
     println(io, "  points: ", length(problem.points), " point(s)")
-    println(io, "  years:  ", problem.years)
+    println(io, "  dates:  ", problem.dates)
     println(io)
     println(io, "forcings:")
     _print_forcing_table(io, _forcing_origins(problem))

--- a/test/micro_raster.jl
+++ b/test/micro_raster.jl
@@ -1,4 +1,5 @@
 using Test
+using Dates
 using MicroclimateMapper
 using MicroclimateMapper: _canonical_data, _is_special_key, _resolve_init, _DEFAULT_INIT,
     _to_extent, _build_area_mask, _first_active_index, _is_active
@@ -76,21 +77,26 @@ end
         weather_source = TerraClimate{Historical},
     )
     area = Extent(X = (146.0, 146.1), Y = (-36.0, -35.9))
-    years = 2000:2000
+    dates = Date(2000, 1, 1):Day(1):Date(2000, 12, 31)
     soil_profile = example_soil_profile(inner.depths)
 
-    problem = MicroRasterProblem(; model, area, years, template = SRTM, soil_profile)
+    problem = MicroRasterProblem(; model, area, dates, template = SRTM, soil_profile)
     @test problem.model === model
     @test problem.area === area
-    @test problem.years === years
+    @test problem.dates === dates
     @test problem.template === SRTM
     @test problem.soil_profile === soil_profile
     @test problem.init === nothing
     @test problem.data === (;)
 
+    # Single-day run
+    problem_day = MicroRasterProblem(;
+        model, area, dates = Date(2000, 6, 29), template = SRTM, soil_profile)
+    @test problem_day.dates === Date(2000, 6, 29)
+
     # Custom init + data overrides
     problem2 = MicroRasterProblem(;
-        model, area, years, template = SRTM, soil_profile,
+        model, area, dates, template = SRTM, soil_profile,
         init = (soil_temperature = nothing, soil_moisture = fill(0.1, 10)),
         data = (; vapour_pressure_deficit = Raster(zeros(2, 2), (X(1:2), Y(1:2)))),
     )

--- a/test/micro_vector.jl
+++ b/test/micro_vector.jl
@@ -1,4 +1,5 @@
 using Test
+using Dates
 using MicroclimateMapper
 using MicroclimateMapper: _make_points_dim, _points_extent,
     _to_points, _to_points_constant, _to_points_with_time,
@@ -98,19 +99,24 @@ end
         dem_source = SRTM,
         weather_source = TerraClimate{Historical},
     )
-    years = 2000:2000
+    dates = Date(2000, 1, 1):Day(1):Date(2000, 12, 31)
     soil_profile = example_soil_profile(inner.depths)
 
-    problem = MicroVectorProblem(; model, points = POINTS, years, soil_profile)
+    problem = MicroVectorProblem(; model, points = POINTS, dates, soil_profile)
     @test problem.model === model
     @test problem.points === POINTS
-    @test problem.years === years
+    @test problem.dates === dates
     @test problem.soil_profile === soil_profile
     @test problem.init === nothing
     @test problem.data === (;)
 
+    # Single-day run
+    problem_day = MicroVectorProblem(;
+        model, points = POINTS, dates = Date(2000, 6, 29), soil_profile)
+    @test problem_day.dates === Date(2000, 6, 29)
+
     problem2 = MicroVectorProblem(;
-        model, points = POINTS, years, soil_profile,
+        model, points = POINTS, dates, soil_profile,
         init = (soil_temperature = nothing, soil_moisture = fill(0.1, 10)),
         data = (; vapour_pressure_deficit = Raster(zeros(2, 2), (X(1:2), Y(1:2)))),
     )


### PR DESCRIPTION
Replaces temporal specification from running whole years to specifying date ranges, allowing sub-yearly simulations and starting and finishing simulations part way through years. 